### PR TITLE
Fix README build instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,5 +7,5 @@ Pasos para ejecutar Proyectos
 3.- Correr 'npm run dev'
 
 ## Producción
-1.- Correo 'npm run build'
+1.- Correr 'npm run build'
 2.- Tomar la carpeta "dist" y desplegarla


### PR DESCRIPTION
## Summary
- correct typo in README production command

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6868b8c5dbf48329a50103c2e77dbf82